### PR TITLE
compatibility shim, file level events in lion, runtime version detection

### DIFF
--- a/CDEvent.h
+++ b/CDEvent.h
@@ -38,7 +38,6 @@
 #import <Foundation/Foundation.h>
 #import <CoreServices/CoreServices.h>
 
-
 #pragma mark -
 #pragma mark CDEvent types
 /**
@@ -121,6 +120,14 @@ typedef FSEventStreamEventFlags CDEventFlags;
  * @since 1.0.0
  */
 @property (readonly) CDEventFlags				flags;
+
+#pragma mark flag macros
+
+#define FLAG_CHECK(flags, flag) ((flags) & (flag))
+
+#define FLAG_PROPERTY(name, flag)                   \
+- (BOOL)name                                        \
+{ return (FLAG_CHECK(_flags, flag) ? YES : NO); }
 
 #pragma mark Specific flag properties
 /**
@@ -353,6 +360,24 @@ typedef FSEventStreamEventFlags CDEventFlags;
  */
 @property (readonly) BOOL						didVolumeUnmount;
 
+
+/**
+ * The entirety of the documentation on file level events in lion is 3 sentences
+ * long. Rename behavior is odd, making the combination of events and flags
+ * somewhat confusing for atomic writes. It also appears possible to get a
+ * singular event where a file has been created, modified, and removed.
+ */
+@property (readonly) BOOL                       isCreated;
+@property (readonly) BOOL                       isRemoved;
+@property (readonly) BOOL                       isInodeMetadataModified;
+@property (readonly) BOOL                       isRenamed;
+@property (readonly) BOOL                       isModified;
+@property (readonly) BOOL                       isFinderInfoModified;
+@property (readonly) BOOL                       didChangeOwner;
+@property (readonly) BOOL                       isXattrModified;
+@property (readonly) BOOL                       isFile;
+@property (readonly) BOOL                       isDir;
+@property (readonly) BOOL                       isSymlink;
 
 #pragma mark Class object creators
 /** @name Creating CDEvent Objects */

--- a/CDEvent.m
+++ b/CDEvent.m
@@ -27,7 +27,7 @@
  */
 
 #import "CDEvent.h"
-
+#import "compat.h"
 
 @implementation CDEvent
 
@@ -104,52 +104,33 @@
 	return [self retain];
 }
 
-
 #pragma mark Specific flag properties 
 - (BOOL)isGenericChange
 {
 	return (kFSEventStreamEventFlagNone == _flags);
 }
 
-- (BOOL)mustRescanSubDirectories
-{
-	return (_flags & kFSEventStreamEventFlagMustScanSubDirs);
-}
+FLAG_PROPERTY(mustRescanSubDirectories,     kFSEventStreamEventFlagMustScanSubDirs)
+FLAG_PROPERTY(isUserDropped,                kFSEventStreamEventFlagUserDropped)
+FLAG_PROPERTY(isKernelDropped,              kFSEventStreamEventFlagKernelDropped)
+FLAG_PROPERTY(isEventIdentifiersWrapped,    kFSEventStreamEventFlagEventIdsWrapped)
+FLAG_PROPERTY(isHistoryDone,                kFSEventStreamEventFlagHistoryDone)
+FLAG_PROPERTY(isRootChanged,                kFSEventStreamEventFlagRootChanged)
+FLAG_PROPERTY(didVolumeMount,               kFSEventStreamEventFlagMount)
+FLAG_PROPERTY(didVolumeUnmount,             kFSEventStreamEventFlagUnmount)
 
-- (BOOL)isUserDropped
-{
-	return (_flags & kFSEventStreamEventFlagUserDropped);
-}
-
-- (BOOL)isKernelDropped
-{
-	return (_flags & kFSEventStreamEventFlagKernelDropped);
-}
-
-- (BOOL)isEventIdentifiersWrapped
-{
-	return (_flags & kFSEventStreamEventFlagEventIdsWrapped);
-}
-
-- (BOOL)isHistoryDone
-{
-	return (_flags & kFSEventStreamEventFlagHistoryDone);
-}
-
-- (BOOL)isRootChanged
-{
-	return (_flags & kFSEventStreamEventFlagRootChanged);
-}
-
-- (BOOL)didVolumeMount
-{
-	return (_flags & kFSEventStreamEventFlagMount);
-}
-
-- (BOOL)didVolumeUnmount
-{
-	return (_flags & kFSEventStreamEventFlagUnmount);
-}
+// file-level events introduced in 10.7
+FLAG_PROPERTY(isCreated,                    kFSEventStreamEventFlagItemCreated)
+FLAG_PROPERTY(isRemoved,                    kFSEventStreamEventFlagItemRemoved)
+FLAG_PROPERTY(isInodeMetadataModified,      kFSEventStreamEventFlagItemInodeMetaMod)
+FLAG_PROPERTY(isRenamed,                    kFSEventStreamEventFlagItemRenamed)
+FLAG_PROPERTY(isModified,                   kFSEventStreamEventFlagItemModified)
+FLAG_PROPERTY(isFinderInfoModified,         kFSEventStreamEventFlagItemFinderInfoMod)
+FLAG_PROPERTY(didChangeOwner,               kFSEventStreamEventFlagItemChangeOwner)
+FLAG_PROPERTY(isXattrModified,              kFSEventStreamEventFlagItemXattrMod)
+FLAG_PROPERTY(isFile,                       kFSEventStreamEventFlagItemIsFile)
+FLAG_PROPERTY(isDir,                        kFSEventStreamEventFlagItemIsDir)
+FLAG_PROPERTY(isSymlink,                    kFSEventStreamEventFlagItemIsSymlink)
 
 #pragma mark Misc
 - (NSString *)description

--- a/CDEvents.xcodeproj/project.pbxproj
+++ b/CDEvents.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		6A05775A1400F49900BF73C4 /* compat.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A0577591400F49900BF73C4 /* compat.h */; };
 		8DC2EF530486A6940098B216 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 089C1666FE841158C02AAC07 /* InfoPlist.strings */; };
 		9C6D03031166AFFA00343E46 /* CDEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 9C6D03011166AFFA00343E46 /* CDEvent.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9C6D03041166AFFA00343E46 /* CDEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C6D03021166AFFA00343E46 /* CDEvent.m */; };
@@ -50,6 +51,7 @@
 		089C1667FE841158C02AAC07 /* English */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = English; path = English.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		1058C7B1FEA5585E11CA2CBB /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
 		32DBCF5E0370ADEE00C91783 /* CDEvents_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDEvents_Prefix.pch; sourceTree = "<group>"; };
+		6A0577591400F49900BF73C4 /* compat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = compat.h; sourceTree = "<group>"; };
 		8DC2EF5A0486A6940098B216 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8DC2EF5B0486A6940098B216 /* CDEvents.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CDEvents.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9C6D03011166AFFA00343E46 /* CDEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDEvent.h; sourceTree = "<group>"; };
@@ -163,6 +165,7 @@
 		32C88DFF0371C24200C91783 /* Other Sources */ = {
 			isa = PBXGroup;
 			children = (
+				6A0577591400F49900BF73C4 /* compat.h */,
 				32DBCF5E0370ADEE00C91783 /* CDEvents_Prefix.pch */,
 			);
 			name = "Other Sources";
@@ -188,6 +191,7 @@
 				9C6D03031166AFFA00343E46 /* CDEvent.h in Headers */,
 				9C6D051D1166BD5800343E46 /* CDEventsDelegate.h in Headers */,
 				9C6D05241166BF5300343E46 /* CDEvents.h in Headers */,
+				6A05775A1400F49900BF73C4 /* compat.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/CDEvents.xcodeproj/project.pbxproj
+++ b/CDEvents.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 45;
+	objectVersion = 46;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -237,8 +237,11 @@
 /* Begin PBXProject section */
 		0867D690FE84028FC02AAC07 /* Project object */ = {
 			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0420;
+			};
 			buildConfigurationList = 1DEB91B108733DA50010E9CD /* Build configuration list for PBXProject "CDEvents" */;
-			compatibilityVersion = "Xcode 3.1";
+			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 1;
 			knownRegions = (
@@ -326,7 +329,6 @@
 				DYLIB_CURRENT_VERSION = 1;
 				FRAMEWORK_VERSION = A;
 				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_ENABLE_FIX_AND_CONTINUE = YES;
 				GCC_ENABLE_OBJC_GC = supported;
 				GCC_MODEL_TUNING = G5;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -374,7 +376,6 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.5;
 				ONLY_ACTIVE_ARCH = YES;
-				PREBINDING = NO;
 				RUN_CLANG_STATIC_ANALYZER = YES;
 				SDKROOT = macosx;
 			};
@@ -392,7 +393,6 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.5;
-				PREBINDING = NO;
 				RUN_CLANG_STATIC_ANALYZER = YES;
 				SDKROOT = macosx;
 			};
@@ -404,7 +404,6 @@
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				COPY_PHASE_STRIP = NO;
 				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_ENABLE_FIX_AND_CONTINUE = YES;
 				GCC_ENABLE_OBJC_GC = unsupported;
 				GCC_MODEL_TUNING = G5;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -420,7 +419,6 @@
 					"-framework",
 					AppKit,
 				);
-				PREBINDING = NO;
 				PRODUCT_NAME = CDEventsTestApp;
 			};
 			name = Debug;
@@ -431,7 +429,6 @@
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				GCC_ENABLE_FIX_AND_CONTINUE = NO;
 				GCC_ENABLE_OBJC_GC = unsupported;
 				GCC_MODEL_TUNING = G5;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -446,7 +443,6 @@
 					"-framework",
 					AppKit,
 				);
-				PREBINDING = NO;
 				PRODUCT_NAME = CDEventsTestApp;
 				ZERO_LINK = NO;
 			};

--- a/TestApp/CDEventsTestAppController.m
+++ b/TestApp/CDEventsTestAppController.m
@@ -31,6 +31,23 @@
 #import <CDEvents/CDEvents.h>
 
 
+bool systemVersionIsAtLeast(SInt32 major, SInt32 minor)
+{
+    static SInt32 versionMajor = 0, versionMinor = 0;
+
+    if (versionMajor == 0) {
+        Gestalt(gestaltSystemVersionMajor, &versionMajor);
+    }
+
+    if (versionMinor == 0) {
+        Gestalt(gestaltSystemVersionMinor, &versionMinor);
+    }
+
+    return ((versionMajor > major) ||
+            ((versionMajor == major) && (versionMinor >= minor)));
+}
+
+
 @implementation CDEventsTestAppController
 
 - (void)run
@@ -42,6 +59,16 @@
 							[NSURL URLWithString:[[NSHomeDirectory() stringByAppendingPathComponent:@"Downloads"]
 									stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]]];
 	
+    CDEventsEventStreamCreationFlags creationFlags = kCDEventsDefaultEventStreamFlags;
+
+    if (systemVersionIsAtLeast(10,6)) {
+        creationFlags |= kFSEventStreamCreateFlagIgnoreSelf;
+    }
+
+    if (systemVersionIsAtLeast(10,7)) {
+        creationFlags |= kFSEventStreamCreateFlagFileEvents;
+    }
+
 	_events = [[CDEvents alloc] initWithURLs:watchedURLs
 									delegate:self
 								   onRunLoop:[NSRunLoop currentRunLoop]
@@ -49,7 +76,7 @@
 						notificationLantency:CD_EVENTS_DEFAULT_NOTIFICATION_LATENCY
 					 ignoreEventsFromSubDirs:CD_EVENTS_DEFAULT_IGNORE_EVENT_FROM_SUB_DIRS
 								 excludeURLs:excludeURLs
-						 streamCreationFlags:kCDEventsDefaultEventStreamFlags];
+						 streamCreationFlags:creationFlags];
 	//[_events setIgnoreEventsFromSubDirectories:YES];
 	
 	NSLog(@"-[CDEventsTestAppController run]:\n%@\n------\n%@",

--- a/compat.h
+++ b/compat.h
@@ -1,0 +1,32 @@
+/**
+ * @headerfile compat.h
+ * FSEventStream flag compatibility shim
+ *
+ * In order to compile a binary against an older SDK yet still support the
+ * features present in later OS releases, we need to define any missing enum
+ * constants not present in the older SDK. This allows us to safely defer
+ * feature detection to runtime (and avoid recompilation).
+ */
+
+#import <CoreServices/CoreServices.h>
+
+#if MAC_OS_X_VERSION_MAX_ALLOWED < 1060
+// ignoring events originating from the current process introduced in 10.6
+FSEventStreamCreateFlags kFSEventStreamCreateFlagIgnoreSelf = 0x00000008;
+#endif
+
+#if MAC_OS_X_VERSION_MAX_ALLOWED < 1070
+// file-level events introduced in 10.7
+FSEventStreamCreateFlags kFSEventStreamCreateFlagFileEvents = 0x00000010;
+FSEventStreamEventFlags kFSEventStreamEventFlagItemCreated = 0x00000100,
+                        kFSEventStreamEventFlagItemRemoved = 0x00000200,
+                        kFSEventStreamEventFlagItemInodeMetaMod = 0x00000400,
+                        kFSEventStreamEventFlagItemRenamed = 0x00000800,
+                        kFSEventStreamEventFlagItemModified = 0x00001000,
+                        kFSEventStreamEventFlagItemFinderInfoMod = 0x00002000,
+                        kFSEventStreamEventFlagItemChangeOwner = 0x00004000,
+                        kFSEventStreamEventFlagItemXattrMod = 0x00008000,
+                        kFSEventStreamEventFlagItemIsFile = 0x00010000,
+                        kFSEventStreamEventFlagItemIsDir = 0x00020000,
+                        kFSEventStreamEventFlagItemIsSymlink = 0x00040000;
+#endif


### PR DESCRIPTION
The title essentially says it. I'd appreciate a look through the diff, if only for code review.

C isn't a language that quite makes me happy per se, so I'm looking forward to cheating and re-implementing fsevent_watch in ObjC with CDEvents. This is the first chunk of functionality I attempted to move over.

There are changes in your ARC branch not necessarily related to ARC that I'm guessing I'd want to include in this version of the project. I'd also like to create initializers that take booleans for enabling flags rather than the raw flags value, but I'm new to ObjC and am unsure quite how to do that without creating way too many initializer variants... Coming from ruby/python the schism between named arguments and selectors is a bit jarring. ;)
