### PR TITLE
CDEvents creates CDEvent objects with file URLs

### DIFF
--- a/CDEvents.m
+++ b/CDEvents.m
@@ -317,7 +317,7 @@ static void CDEventsCallback(
 		// We do this hackery to ensure that the eventPath string doesn't
 		// contain any trailing slash.
 		NSString *eventPath = [[eventPathsArray objectAtIndex:i] stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
-		NSURL *eventURL		= [NSURL URLWithString:eventPath];
+		NSURL *eventURL		= [NSURL fileURLWithPath:eventPath];
 		eventPath			= [eventURL path];
 		
 		// Ignore all events except for the URLs we are explicitly watching.


### PR DESCRIPTION
Normal Cocoa API creates file URL objects for file urls, but `CDEvent` creates only normal URLs. When comparing a `CDEvent` URL with one from eg. `NSFileManager` via `isEqual:` it will return false even though both URLs are "equal". Fixed this by letting `CDEvents` create file URLs.
