### PR TITLE
Correctly handle path that contains spaces

### DIFF
--- a/CDEvents.m
+++ b/CDEvents.m
@@ -316,9 +316,8 @@ static void CDEventsCallback(
 		
 		// We do this hackery to ensure that the eventPath string doesn't
 		// contain any trailing slash.
-		NSString *eventPath = [[eventPathsArray objectAtIndex:i] stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
-		NSURL *eventURL		= [NSURL fileURLWithPath:eventPath];
-		eventPath			= [eventURL path];
+		NSURL *eventURL		= [NSURL fileURLWithPath:[[eventPathsArray objectAtIndex:i] stringByStandardizingPath]];
+		NSString *eventPath	= [eventURL path];
 		
 		// Ignore all events except for the URLs we are explicitly watching.
 		if ([watcher ignoreEventsFromSubDirectories]) {


### PR DESCRIPTION
Currently spaces in path are escaped twice. 

``` objective-c
NSString *p = [@"/my folder" stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding] // => @"/my%20folder"
NSURL *u = [NSURL fileURLWithString:p] // => file://localhost/my%2520folder
NSString *p2 = [u path] //=> @"/my%20folder"
@"/my%20folder" != @"/my folder"
```

Using `stringByStandardizingPath` will still guarantee that eventPath doesn't contain trailing slash.
