### PR TITLE
Removing import compat.h

### DIFF
--- a/CDEvent.m
+++ b/CDEvent.m
@@ -27,7 +27,6 @@
  */
 
 #import "CDEvent.h"
-#import "compat.h"
 
 @implementation CDEvent
 


### PR DESCRIPTION
Causes import error and is not necessary. Removing for good. 
