### PR TITLE
CDEvent should maintain strong references to its properties.

### DIFF
--- a/CDEvent.h
+++ b/CDEvent.h
@@ -89,7 +89,7 @@ typedef FSEventStreamEventFlags CDEventFlags;
  *
  * @since 1.0.0
  */
-@property (unsafe_unretained, readonly) NSDate	*date;
+@property (readonly) NSDate	*date;
 
 /**
  * The URL of the item which changed.
@@ -98,7 +98,7 @@ typedef FSEventStreamEventFlags CDEventFlags;
  *
  * @since 1.0.0
  */
-@property (unsafe_unretained, readonly) NSURL	*URL;
+@property (readonly) NSURL	*URL;
 
 
 /** @name Getting Event Flags */

--- a/CDEvent.h
+++ b/CDEvent.h
@@ -89,7 +89,7 @@ typedef FSEventStreamEventFlags CDEventFlags;
  *
  * @since 1.0.0
  */
-@property (readonly) NSDate	*date;
+@property (strong, readonly) NSDate	*date;
 
 /**
  * The URL of the item which changed.
@@ -98,7 +98,7 @@ typedef FSEventStreamEventFlags CDEventFlags;
  *
  * @since 1.0.0
  */
-@property (readonly) NSURL	*URL;
+@property (strong, readonly) NSURL	*URL;
 
 
 /** @name Getting Event Flags */


### PR DESCRIPTION
Unretained property is source of headaches:

``` objc
- (void)foo {
    self.events = [[CDEvents alloc] initWithURLs:URLs
                                           block:^(CDEvents *watcher, CDEvent *event) {
                                               self.lastEvent = event;
                                           }];
}

- (void)bar {
    // Remember the URL property is unsafe_unretained.
    NSLog(@"%@", self.lastEvent.URL); // BOOM!
}
```
