### PR TITLE
Don't export flag macros.

### DIFF
--- a/CDEvent.h
+++ b/CDEvent.h
@@ -115,14 +115,6 @@ typedef FSEventStreamEventFlags CDEventFlags;
  */
 @property (readonly) CDEventFlags				flags;
 
-#pragma mark flag macros
-
-#define FLAG_CHECK(flags, flag) ((flags) & (flag))
-
-#define FLAG_PROPERTY(name, flag)                   \
-- (BOOL)name                                        \
-{ return (FLAG_CHECK(_flags, flag) ? YES : NO); }
-
 #pragma mark Specific flag properties
 /**
  * Wheter there was some change in the directory at the specific path supplied in this event.

--- a/CDEvent.m
+++ b/CDEvent.m
@@ -102,6 +102,12 @@
 	return (kFSEventStreamEventFlagNone == _flags);
 }
 
+#define FLAG_CHECK(flags, flag) ((flags) & (flag))
+
+#define FLAG_PROPERTY(name, flag)                   \
+- (BOOL)name                                        \
+{ return (FLAG_CHECK(_flags, flag) ? YES : NO); }
+
 FLAG_PROPERTY(mustRescanSubDirectories,     kFSEventStreamEventFlagMustScanSubDirs)
 FLAG_PROPERTY(isUserDropped,                kFSEventStreamEventFlagUserDropped)
 FLAG_PROPERTY(isKernelDropped,              kFSEventStreamEventFlagKernelDropped)


### PR DESCRIPTION
`FLAG_CHECK` and `FLAG_PROPERTY` are implementation details so they should live in implementation file rather than header file.
