### PR TITLE
Casting Warnings in XCode 5

### DIFF
--- a/CDEvent.m
+++ b/CDEvent.m
@@ -83,7 +83,7 @@
 	self = [self initWithIdentifier:[[aDecoder decodeObjectForKey:@"identifier"] unsignedIntegerValue]
 							   date:[aDecoder decodeObjectForKey:@"date"]
 								URL:[aDecoder decodeObjectForKey:@"URL"]
-							  flags:[[aDecoder decodeObjectForKey:@"flags"] unsignedIntegerValue]];
+							  flags:(uint) [[aDecoder decodeObjectForKey:@"flags"] unsignedIntegerValue]];
 	
 	return self;
 }

--- a/CDEvent.m
+++ b/CDEvent.m
@@ -83,7 +83,7 @@
 	self = [self initWithIdentifier:[[aDecoder decodeObjectForKey:@"identifier"] unsignedIntegerValue]
 							   date:[aDecoder decodeObjectForKey:@"date"]
 								URL:[aDecoder decodeObjectForKey:@"URL"]
-							  flags:(uint) [[aDecoder decodeObjectForKey:@"flags"] unsignedIntegerValue]];
+							  flags:[[aDecoder decodeObjectForKey:@"flags"] unsignedIntValue]];
 	
 	return self;
 }

--- a/CDEvents.m
+++ b/CDEvents.m
@@ -249,7 +249,7 @@ streamCreationFlags:(CDEventsEventStreamCreationFlags)streamCreationFlags
 							   notificationLantency:[self notificationLatency]
 							ignoreEventsFromSubDirs:[self ignoreEventsFromSubDirectories]
 										excludeURLs:[self excludedURLs]
-								streamCreationFlags:_eventStreamCreationFlags];
+								streamCreationFlags:(uint) _eventStreamCreationFlags];
 	
 	return copy;
 }
@@ -313,7 +313,7 @@ streamCreationFlags:(CDEventsEventStreamCreationFlags)streamCreationFlags
 									   (__bridge CFArrayRef)watchedPaths,
 									   (FSEventStreamEventId)[self sinceEventIdentifier],
 									   [self notificationLatency],
-									   _eventStreamCreationFlags);
+									   (uint) _eventStreamCreationFlags);
 }
 
 - (void)disposeEventStream

--- a/CDEvents.m
+++ b/CDEvents.m
@@ -60,10 +60,10 @@ const CDEventIdentifier kCDEventsSinceEventNow = kFSEventStreamEventIdSinceNow;
 // Private API
 @interface CDEvents () {
 @private
-	CDEventsEventBlock	_eventBlock;
+	CDEventsEventBlock                          _eventBlock;
 	
-	FSEventStreamRef	_eventStream;
-	NSUInteger			_eventStreamCreationFlags;
+	FSEventStreamRef							_eventStream;
+	CDEventsEventStreamCreationFlags			_eventStreamCreationFlags;
 }
 
 // Redefine the properties that should be writeable.
@@ -249,7 +249,7 @@ streamCreationFlags:(CDEventsEventStreamCreationFlags)streamCreationFlags
 							   notificationLantency:[self notificationLatency]
 							ignoreEventsFromSubDirs:[self ignoreEventsFromSubDirectories]
 										excludeURLs:[self excludedURLs]
-								streamCreationFlags:(uint) _eventStreamCreationFlags];
+								streamCreationFlags:_eventStreamCreationFlags];
 	
 	return copy;
 }


### PR DESCRIPTION
...lags (Due to Warnings in XCode 5)

This is due to new warnings introduced in XCode 5.
